### PR TITLE
fix: use createElement on Document to avoid invalid append

### DIFF
--- a/src/core/sandboxExecutor.ts
+++ b/src/core/sandboxExecutor.ts
@@ -73,7 +73,7 @@ export function executeSandboxedJS(
   timeoutMs = DEFAULT_TIMEOUT_MS,
 ): Promise<string> {
   return new Promise<string>((resolve, reject) => {
-    const iframe = activeDocument.createEl("iframe");
+    const iframe = activeDocument.createElement("iframe");
     iframe.sandbox.add("allow-scripts");
     iframe.setCssStyles({ display: "none" });
 

--- a/src/ui/components/workflow/AIWorkflowModal.ts
+++ b/src/ui/components/workflow/AIWorkflowModal.ts
@@ -1972,7 +1972,7 @@ ${formattedSteps}
   private addResizeHandles(modalEl: HTMLElement): void {
     const directions = ["n", "e", "s", "w", "ne", "nw", "se", "sw"];
     for (const dir of directions) {
-      const handle = activeDocument.createDiv();
+      const handle = activeDocument.createElement("div");
       handle.className = `llm-hub-resize-handle llm-hub-resize-${dir}`;
       handle.dataset.direction = dir;
       modalEl.appendChild(handle);

--- a/src/ui/components/workflow/DiffRenderer.ts
+++ b/src/ui/components/workflow/DiffRenderer.ts
@@ -308,11 +308,11 @@ function createCommentEditor(
   const line = diffLines[lineIndex];
   const existingComment = lineComments.get(lineIndex);
 
-  const editor = activeDocument.createDiv();
+  const editor = activeDocument.createElement("div");
   editor.className = "llm-hub-diff-comment-editor";
   afterEl.insertAdjacentElement("afterend", editor);
 
-  const textarea = activeDocument.createEl("textarea");
+  const textarea = activeDocument.createElement("textarea");
   textarea.className = "llm-hub-diff-comment-input";
   textarea.placeholder = t("diff.commentPlaceholder");
   textarea.rows = 2;
@@ -323,11 +323,11 @@ function createCommentEditor(
   editor.addEventListener("click", (e) => e.stopPropagation());
   editor.appendChild(textarea);
 
-  const actions = activeDocument.createDiv();
+  const actions = activeDocument.createElement("div");
   actions.className = "llm-hub-diff-comment-actions";
   editor.appendChild(actions);
 
-  const saveBtn = activeDocument.createEl("button");
+  const saveBtn = activeDocument.createElement("button");
   saveBtn.textContent = t("diff.saveComment");
   saveBtn.className = "mod-cta";
   saveBtn.addEventListener("click", (e) => {
@@ -350,7 +350,7 @@ function createCommentEditor(
   });
   actions.appendChild(saveBtn);
 
-  const cancelBtn = activeDocument.createEl("button");
+  const cancelBtn = activeDocument.createElement("button");
   cancelBtn.textContent = t("diff.cancelComment");
   cancelBtn.addEventListener("click", (e) => {
     e.stopPropagation();
@@ -359,7 +359,7 @@ function createCommentEditor(
   actions.appendChild(cancelBtn);
 
   if (existingComment) {
-    const removeBtn = activeDocument.createEl("button");
+    const removeBtn = activeDocument.createElement("button");
     removeBtn.textContent = t("diff.removeComment");
     removeBtn.className = "mod-warning";
     removeBtn.addEventListener("click", (e) => {

--- a/src/ui/components/workflow/EditConfirmationModal.ts
+++ b/src/ui/components/workflow/EditConfirmationModal.ts
@@ -289,7 +289,7 @@ export class EditConfirmationModal extends Modal {
   private addResizeHandles(modalEl: HTMLElement) {
     const directions = ["n", "e", "s", "w", "ne", "nw", "se", "sw"];
     for (const dir of directions) {
-      const handle = activeDocument.createDiv();
+      const handle = activeDocument.createElement("div");
       handle.className = `llm-hub-workflow-confirm-resize-handle llm-hub-workflow-confirm-resize-${dir}`;
       handle.dataset.direction = dir;
       modalEl.appendChild(handle);

--- a/src/ui/components/workflow/NodeEditorModal.ts
+++ b/src/ui/components/workflow/NodeEditorModal.ts
@@ -524,11 +524,11 @@ export class NodeEditorModal extends Modal {
       if (suggestions.length === 0) return;
 
       currentSuggestions = suggestions;
-      suggestionContainer = activeDocument.createDiv();
+      suggestionContainer = activeDocument.createElement("div");
       suggestionContainer.addClass("llm-hub-workflow-path-suggestions");
 
       suggestions.forEach((suggestion, index) => {
-        const item = activeDocument.createDiv();
+        const item = activeDocument.createElement("div");
         item.addClass("llm-hub-workflow-path-suggestion-item");
         if (index === selectedIndex) {
           item.addClass("is-selected");

--- a/src/ui/components/workflow/WorkflowGenerationModal.ts
+++ b/src/ui/components/workflow/WorkflowGenerationModal.ts
@@ -248,7 +248,7 @@ export class WorkflowGenerationModal extends Modal {
       this.thinkingSectionEl.removeClass("is-hidden");
     }
     if (this.pendingThinkingSeparator && this.thinkingContainerEl) {
-      const sep = activeDocument.createDiv();
+      const sep = activeDocument.createElement("div");
       sep.className = "llm-hub-workflow-generation-thinking-separator";
       sep.textContent = `── ${this.pendingThinkingSeparator} ──`;
       this.thinkingContainerEl.appendChild(sep);
@@ -256,7 +256,7 @@ export class WorkflowGenerationModal extends Modal {
     }
     this.thinkingText += content;
     if (this.thinkingContainerEl) {
-      const span = activeDocument.createSpan();
+      const span = activeDocument.createElement("span");
       span.textContent = content;
       this.thinkingContainerEl.appendChild(span);
       this.thinkingContainerEl.scrollTop = this.thinkingContainerEl.scrollHeight;
@@ -273,7 +273,7 @@ export class WorkflowGenerationModal extends Modal {
   appendPlan(content: string): void {
     this.planText += content;
     if (this.planContainerEl) {
-      const span = activeDocument.createSpan();
+      const span = activeDocument.createElement("span");
       span.textContent = content;
       this.planContainerEl.appendChild(span);
       this.planContainerEl.scrollTop = this.planContainerEl.scrollHeight;
@@ -283,7 +283,7 @@ export class WorkflowGenerationModal extends Modal {
   appendReview(content: string): void {
     this.reviewText += content;
     if (this.reviewContainerEl) {
-      const span = activeDocument.createSpan();
+      const span = activeDocument.createElement("span");
       span.textContent = content;
       this.reviewContainerEl.appendChild(span);
       this.reviewContainerEl.scrollTop = this.reviewContainerEl.scrollHeight;


### PR DESCRIPTION
Hey, opened a PR directly because the fix was simple, but let me know if that's not how you wanted me to do it.

Really exciting project and super happy to be able to use it!

Below a description of the issue and the fix.

## Root cause

Obsidian's `createEl` / `createDiv` / `createSpan` (extensions on `Node.prototype`) create and append in one step. On a `Document` receiver the append throws — a Document allows only one root element. Every `activeDocument.createEl(...)` / `createDiv()` / `createSpan()` call triggers `Failed to execute 'appendChild' on 'Node': Only one element on document allowed.`

## Solution

Replace 15 call sites with `activeDocument.createElement(tag)`, which doesn't auto-append. Subsequent explicit `appendChild` calls were already correct.

Affected surfaces (all broken on latest version):

- `src/core/sandboxExecutor.ts` — `script` workflow nodes throw before executing user code.
- `src/ui/components/workflow/WorkflowGenerationModal.ts` — "Create workflow with AI" modal renders with no thinking / plan / review content.
- `src/ui/components/workflow/DiffRenderer.ts` — per-line comment editor (textarea, Save / Cancel / Remove) fails to render.
- `src/ui/components/workflow/NodeEditorModal.ts` — path suggestion popup doesn't populate.
- `src/ui/components/workflow/AIWorkflowModal.ts` & `EditConfirmationModal.ts` — drag handles fail to render.

## Manual testing

macOS / Obsidian 1.x. Before / after:

- **Script nodes** — ran a workflow with a `script` first node. Before: throws on the script. After: executes.
- **"Create workflow with AI"** — opened on a note with no workflow block, clicked the button. Before: empty modal. After: thinking, plan, and review sections all populate.

The other three surfaces share the same root cause and fix pattern but were not individually exercised — happy to verify any of them if useful.

No automated test: project has no UI / DOM tests, fix is a literal substitution. Happy to add an ESLint rule banning `activeDocument.create{El,Div,Span}(` as a follow-up if useful.