### PR TITLE
fix: prevent crash when lastActiveMarkdownView has null editor

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -597,7 +597,7 @@ export class LocalLlmHubPlugin extends Plugin {
   getSelection(): string | null {
     // First try live selection from active editor
     const view = this.lastActiveMarkdownView || this.app.workspace.getActiveViewOfType(MarkdownView);
-    if (view) {
+    if (view?.editor) {
       const sel = view.editor.getSelection();
       if (sel) return sel;
     }
@@ -611,7 +611,7 @@ export class LocalLlmHubPlugin extends Plugin {
 
   getActiveNoteContent(): string | null {
     const view = this.lastActiveMarkdownView || this.app.workspace.getActiveViewOfType(MarkdownView);
-    if (!view) return null;
+    if (!view?.editor) return null;
     return view.editor.getValue() || null;
   }
 

--- a/src/plugin/selectionManager.ts
+++ b/src/plugin/selectionManager.ts
@@ -55,7 +55,7 @@ export class SelectionManager {
     this.selectionLocation = null;
 
     const activeView = this.plugin.app.workspace.getActiveViewOfType(MarkdownView);
-    if (activeView) {
+    if (activeView?.editor) {
       const editor = activeView.editor;
       const selection = editor.getSelection();
       if (selection) {


### PR DESCRIPTION
## Problem

Plugin crashes on load with:
  TypeError: Cannot read properties of null (reading 'getSelection')
    at YB.getSelection (plugin:local-llm-hub:1826:5368)

The crash occurs in the selection polling interval (Chat.tsx, every 2s) which calls plugin.getSelection(). When lastActiveMarkdownView is stale (view closed but reference not cleared), view.editor becomes null while view itself still exists, causing null.getSelection() to throw.

## Root Cause

lastActiveMarkdownView is a cached reference that persists after the underlying MarkdownView is detached. During view teardown:
  1. The view object still exists in memory (not null)
  2. view.editor is set to null (CodeMirror unbound)
  3. lastActiveMarkdownView still references this stale view

The code only checked 'if (view)' before accessing view.editor, missing the case where view exists but editor is null.

## Reproduction Steps

1. Open a markdown file (sets lastActiveMarkdownView)
2. Open the chat panel (starts setInterval polling every 2s)
3. Close the markdown view leaf (detach)
4. Wait for poller to fire -> CRASH

Verified via Obsidian MCP:
  - lastActiveMarkdownView: file=fit-test.md, editor=NULL
  - plugin.getSelection() -> CRASH (before fix)
  - plugin.getSelection() -> null (after fix, no crash)

## Fix

Add null-safe optional chaining for editor check in three locations:

  src/plugin.ts:
    - getSelection(): if (view) -> if (view?.editor)
    - getActiveNoteContent(): if (!view) -> if (!view?.editor)

  src/plugin/selectionManager.ts:
    - captureSelection(): if (activeView) -> if (activeView?.editor)

When editor is null, getSelection() gracefully falls through to return the cached selection from selectionManager.getLastSelection() instead of crashing.

## Testing

- A/B test: reverted fix, reproduced crash, re-applied fix, confirmed no errors
- 10+ seconds of poller ticks against stale view with editor=null: zero errors
- Direct plugin.getSelection() call on stale view: returns null safely