### PR TITLE
feat: persist per-request MCP server selection and vault tool mode across reloads

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -535,6 +535,22 @@ export class LocalLlmHubPlugin extends Plugin {
     if (!Array.isArray(this.settings.agentPlugins)) {
       this.settings.agentPlugins = [];
     }
+    // Migrate the old allow-list "enabledMcpServerIds" into the new opt-out map
+    // "mcpServerEnabled". An id in the old allow-list was explicitly enabled, so it
+    // maps to `true` (key present => explicit choice). The old field is then dropped.
+    const rawForMigrate = this.settings as unknown as Record<string, unknown>;
+    if ("enabledMcpServerIds" in rawForMigrate) {
+      const oldList = rawForMigrate.enabledMcpServerIds;
+      if (Array.isArray(oldList) && oldList.length > 0) {
+        const map: Record<string, boolean> = { ...(this.settings.mcpServerEnabled || {}) } as Record<string, boolean>;
+        for (const id of oldList) {
+          if (typeof id === "string") map[id] = true;
+        }
+        this.settings.mcpServerEnabled = map;
+      }
+      delete rawForMigrate.enabledMcpServerIds;
+      needsSave = true;
+    }
 
     // Hydrate the workspace state manager created synchronously in onload so
     // restored views can safely use the default state during startup.

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -535,23 +535,6 @@ export class LocalLlmHubPlugin extends Plugin {
     if (!Array.isArray(this.settings.agentPlugins)) {
       this.settings.agentPlugins = [];
     }
-    // Migrate the old allow-list "enabledMcpServerIds" into the new opt-out map
-    // "mcpServerEnabled". An id in the old allow-list was explicitly enabled, so it
-    // maps to `true` (key present => explicit choice). The old field is then dropped.
-    const rawForMigrate = this.settings as unknown as Record<string, unknown>;
-    if ("enabledMcpServerIds" in rawForMigrate) {
-      const oldList = rawForMigrate.enabledMcpServerIds;
-      if (Array.isArray(oldList) && oldList.length > 0) {
-        const map: Record<string, boolean> = { ...(this.settings.mcpServerEnabled || {}) } as Record<string, boolean>;
-        for (const id of oldList) {
-          if (typeof id === "string") map[id] = true;
-        }
-        this.settings.mcpServerEnabled = map;
-      }
-      delete rawForMigrate.enabledMcpServerIds;
-      needsSave = true;
-    }
-
     // Hydrate the workspace state manager created synchronously in onload so
     // restored views can safely use the default state during startup.
     await this.wsManager.loadOrCreateWorkspaceState();

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -300,10 +300,9 @@ export interface LocalLlmHubSettings {
   vaultToolMode: VaultToolMode;
   /**
    * Per-request per-MCP-server selection persisted in the chat input, stored as an
-   * opt-out MAP keyed by server id: a key present with value false means "disabled",
-   * a key present with value true means "user enabled", and a key that is ABSENT
-   * means "default" (enabled). Absence is the crucial signal that lets us tell an
-   * unset/uninitialized selection apart from an explicit choice to disable.
+   * opt-out map keyed by server id: a value of false means "disabled", while a key
+   * that is absent means "default" (enabled). Absence is the crucial signal that
+   * lets us tell an unset selection apart from an explicit choice to disable.
    *
    * We deliberately moved away from an allow-list of "enabled ids": with an
    * allow-list, an unset field serializes as the same [] value as "user disabled
@@ -341,4 +340,4 @@ export const DEFAULT_SETTINGS: LocalLlmHubSettings = {
   mcpServers: [],
   agentPlugins: [],
   vaultToolMode: "all",
-  };
+};

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -298,8 +298,19 @@ export interface LocalLlmHubSettings {
   agentPlugins: AgentPluginInstall[];
   /** Vault tool mode for the chat input (all | noSearch | none). */
   vaultToolMode: VaultToolMode;
-  /** Per-request MCP server selection in the chat input, persisted across reloads. */
-  enabledMcpServerIds: string[];
+  /**
+   * Per-request per-MCP-server selection persisted in the chat input, stored as an
+   * opt-out MAP keyed by server id: a key present with value false means "disabled",
+   * a key present with value true means "user enabled", and a key that is ABSENT
+   * means "default" (enabled). Absence is the crucial signal that lets us tell an
+   * unset/uninitialized selection apart from an explicit choice to disable.
+   *
+   * We deliberately moved away from an allow-list of "enabled ids": with an
+   * allow-list, an unset field serializes as the same [] value as "user disabled
+   * everything", which made fresh/first users default every connected server OFF on
+   * next reload and let reconnect races silently flip saved state.
+   */
+  mcpServerEnabled?: Partial<Record<string, boolean>>;
 }
 
 /** Fixed skills folder name. */
@@ -330,5 +341,4 @@ export const DEFAULT_SETTINGS: LocalLlmHubSettings = {
   mcpServers: [],
   agentPlugins: [],
   vaultToolMode: "all",
-  enabledMcpServerIds: [],
-};
+  };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -296,6 +296,10 @@ export interface LocalLlmHubSettings {
   knowledgeSources: KnowledgeSource[];
   mcpServers: McpServerConfig[];
   agentPlugins: AgentPluginInstall[];
+  /** Vault tool mode for the chat input (all | noSearch | none). */
+  vaultToolMode: VaultToolMode;
+  /** Per-request MCP server selection in the chat input, persisted across reloads. */
+  enabledMcpServerIds: string[];
 }
 
 /** Fixed skills folder name. */
@@ -325,4 +329,6 @@ export const DEFAULT_SETTINGS: LocalLlmHubSettings = {
   knowledgeSources: [],
   mcpServers: [],
   agentPlugins: [],
+  vaultToolMode: "all",
+  enabledMcpServerIds: [],
 };

--- a/src/ui/components/Chat.tsx
+++ b/src/ui/components/Chat.tsx
@@ -416,20 +416,19 @@ const Chat = forwardRef<ChatRef, ChatProps>(({ plugin }, ref) => {
       } else {
         next.delete(serverId);
       }
-      // Persist the per-request MCP selection as an opt-out map so it survives
-      // reloads. We only record the explicit choice: a server that is enabled
-      // keeps its key absent (default) unless it was previously disabled, and a
-      // disabled server gets an explicit `false`.
-      const map = { ...(plugin.settings.mcpServerEnabled || {}) };
-      if (enabled) {
-        if (map[serverId] === false) delete map[serverId];
-      } else {
-        map[serverId] = false;
-      }
-      plugin.settings.mcpServerEnabled = map;
-      void plugin.saveSettings();
       return next;
     });
+
+    // Persist only explicit opt-outs. An absent key keeps the default enabled
+    // behavior for new servers while false survives reloads and reconnects.
+    const map = { ...(plugin.settings.mcpServerEnabled || {}) };
+    if (enabled) {
+      delete map[serverId];
+    } else {
+      map[serverId] = false;
+    }
+    plugin.settings.mcpServerEnabled = map;
+    void plugin.saveSettings();
   }, [plugin]);
 
   const handleOpenDashboard = useCallback(() => {

--- a/src/ui/components/Chat.tsx
+++ b/src/ui/components/Chat.tsx
@@ -93,11 +93,16 @@ const Chat = forwardRef<ChatRef, ChatProps>(({ plugin }, ref) => {
   const [okfBundles, setOkfBundles] = useState<OkfBundle[]>([]);
   const [activeOkfBundleIds, setActiveOkfBundleIds] = useState<string[]>([]);
   const [mcpServerInfos, setMcpServerInfos] = useState<McpServerInfo[]>([]);
-  const [enabledMcpServerIds, setEnabledMcpServerIds] = useState<Set<string>>(
-    // Seed with the persisted selection so a reload shows the saved state even
-    // before the first async MCP refresh completes.
-    () => new Set(plugin.settings.enabledMcpServerIds || [])
-  );
+  const [enabledMcpServerIds, setEnabledMcpServerIds] = useState<Set<string>>(() => {
+    // Reconstruct the allowed set from the persisted opt-out map on mount: a server is
+    // enabled UNLESS it has an explicit `false`, so absent keys keep the old default of
+    // "enabled" and never flip fresh / uninitialised users onto an all-off list.
+    const allowed = new Set<string>();
+    for (const id of plugin.mcpManager.getServerInfos().map(info => info.id)) {
+      if (plugin.settings.mcpServerEnabled?.[id] !== false) allowed.add(id);
+    }
+    return allowed;
+  });
   const [currentDashboard, setCurrentDashboard] = useState<TFile | null>(null);
   const [activeContextSkillPath, setActiveContextSkillPath] = useState<string | null>(null);
   const [disabledContextSkillPaths, setDisabledContextSkillPaths] = useState<Set<string>>(
@@ -117,12 +122,6 @@ const Chat = forwardRef<ChatRef, ChatProps>(({ plugin }, ref) => {
       CONTEXT_SKILL_PATHS,
       skillPath,
     ), [activeSkillPaths, activeContextSkillPath, disabledContextSkillPaths]);
-  const knownMcpServerIdsRef = useRef<Set<string>>(new Set());
-  // Becomes true only after the first refresh that actually saw connected
-  // servers. This avoids the async race on startup where the first refresh
-  // runs before MCP servers finish connecting, which would otherwise flip
-  // the "first load" branch off too early and auto-enable every server.
-  const mcpInitialRestoreDoneRef = useRef(false);
 
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const abortControllerRef = useRef<AbortController | null>(null);
@@ -245,27 +244,18 @@ const Chat = forwardRef<ChatRef, ChatProps>(({ plugin }, ref) => {
     const infos = plugin.mcpManager.getServerInfos();
     setMcpServerInfos(infos);
     const connectedIds = new Set(infos.map(info => info.id));
-    const previouslyKnownIds = knownMcpServerIdsRef.current;
-    knownMcpServerIdsRef.current = connectedIds;
-    // Only treat this as the initial restore once servers are actually present,
-    // so the async startup window (refresh fires before connectAll finishes)
-    // does not prematurely disable the "restore from saved" branch.
-    const firstLoad = !mcpInitialRestoreDoneRef.current;
-    if (connectedIds.size > 0) mcpInitialRestoreDoneRef.current = true;
-    setEnabledMcpServerIds(prev => {
-      // On first load, strictly restore the persisted per-request selection and
-      // do NOT auto-enable connected servers. After that, newly connected
-      // servers start enabled but explicit opt-outs are preserved.
-      if (firstLoad) {
-        const saved = new Set(plugin.settings.enabledMcpServerIds || []);
-        return new Set([...saved].filter(id => connectedIds.has(id)));
-      }
-      const next = new Set([...prev].filter(id => connectedIds.has(id)));
-      for (const id of connectedIds) {
-        if (!previouslyKnownIds.has(id)) next.add(id);
-      }
-      return next;
-    });
+    // The persisted opt-out MAP is the single source of truth for which connected
+    // servers are enabled. Absence of a key means the default (enabled), so:
+    //  - fresh / first-time users (no key) keep the old "connected servers start
+    //    enabled" behaviour (Bug 1: [] no longer means "disable everything");
+    //  - an explicitly disabled server stays disabled even across reconnects,
+    //    because the map is NOT rebuilt from connection state (Bug 2).
+    const saved = plugin.settings.mcpServerEnabled || {};
+    const next = new Set<string>();
+    for (const id of connectedIds) {
+      if (saved[id] !== false) next.add(id);
+    }
+    setEnabledMcpServerIds(next);
   }, [plugin]);
 
   useEffect(() => {
@@ -426,8 +416,17 @@ const Chat = forwardRef<ChatRef, ChatProps>(({ plugin }, ref) => {
       } else {
         next.delete(serverId);
       }
-      // Persist the per-request MCP selection so it survives reloads.
-      plugin.settings.enabledMcpServerIds = [...next];
+      // Persist the per-request MCP selection as an opt-out map so it survives
+      // reloads. We only record the explicit choice: a server that is enabled
+      // keeps its key absent (default) unless it was previously disabled, and a
+      // disabled server gets an explicit `false`.
+      const map = { ...(plugin.settings.mcpServerEnabled || {}) };
+      if (enabled) {
+        if (map[serverId] === false) delete map[serverId];
+      } else {
+        map[serverId] = false;
+      }
+      plugin.settings.mcpServerEnabled = map;
       void plugin.saveSettings();
       return next;
     });

--- a/src/ui/components/Chat.tsx
+++ b/src/ui/components/Chat.tsx
@@ -83,7 +83,7 @@ const Chat = forwardRef<ChatRef, ChatProps>(({ plugin }, ref) => {
   const [ragSettingNames, setRagSettingNames] = useState<string[]>(plugin.getRagSettingNames());
   const [selectedRagSetting, setSelectedRagSetting] = useState<string | null>(plugin.getSelectedRagSettingName());
   const [ragEnabled, setRagEnabled] = useState(true);
-  const [vaultToolMode, setVaultToolMode] = useState<VaultToolMode>("all");
+  const [vaultToolMode, setVaultToolMode] = useState<VaultToolMode>(plugin.settings.vaultToolMode ?? "all");
   const [vaultFiles, setVaultFiles] = useState<string[]>([]);
   const [hasSelection, setHasSelection] = useState(false);
   const [availableSkills, setAvailableSkills] = useState<SkillMetadata[]>(getBuiltinSkillMetadata);
@@ -93,7 +93,11 @@ const Chat = forwardRef<ChatRef, ChatProps>(({ plugin }, ref) => {
   const [okfBundles, setOkfBundles] = useState<OkfBundle[]>([]);
   const [activeOkfBundleIds, setActiveOkfBundleIds] = useState<string[]>([]);
   const [mcpServerInfos, setMcpServerInfos] = useState<McpServerInfo[]>([]);
-  const [enabledMcpServerIds, setEnabledMcpServerIds] = useState<Set<string>>(new Set());
+  const [enabledMcpServerIds, setEnabledMcpServerIds] = useState<Set<string>>(
+    // Seed with the persisted selection so a reload shows the saved state even
+    // before the first async MCP refresh completes.
+    () => new Set(plugin.settings.enabledMcpServerIds || [])
+  );
   const [currentDashboard, setCurrentDashboard] = useState<TFile | null>(null);
   const [activeContextSkillPath, setActiveContextSkillPath] = useState<string | null>(null);
   const [disabledContextSkillPaths, setDisabledContextSkillPaths] = useState<Set<string>>(
@@ -114,7 +118,11 @@ const Chat = forwardRef<ChatRef, ChatProps>(({ plugin }, ref) => {
       skillPath,
     ), [activeSkillPaths, activeContextSkillPath, disabledContextSkillPaths]);
   const knownMcpServerIdsRef = useRef<Set<string>>(new Set());
-  const mcpSelectionInitializedRef = useRef(false);
+  // Becomes true only after the first refresh that actually saw connected
+  // servers. This avoids the async race on startup where the first refresh
+  // runs before MCP servers finish connecting, which would otherwise flip
+  // the "first load" branch off too early and auto-enable every server.
+  const mcpInitialRestoreDoneRef = useRef(false);
 
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const abortControllerRef = useRef<AbortController | null>(null);
@@ -238,13 +246,20 @@ const Chat = forwardRef<ChatRef, ChatProps>(({ plugin }, ref) => {
     setMcpServerInfos(infos);
     const connectedIds = new Set(infos.map(info => info.id));
     const previouslyKnownIds = knownMcpServerIdsRef.current;
-    const firstLoad = !mcpSelectionInitializedRef.current;
     knownMcpServerIdsRef.current = connectedIds;
-    mcpSelectionInitializedRef.current = true;
+    // Only treat this as the initial restore once servers are actually present,
+    // so the async startup window (refresh fires before connectAll finishes)
+    // does not prematurely disable the "restore from saved" branch.
+    const firstLoad = !mcpInitialRestoreDoneRef.current;
+    if (connectedIds.size > 0) mcpInitialRestoreDoneRef.current = true;
     setEnabledMcpServerIds(prev => {
-      // Enable connected servers on first load, then preserve explicit opt-outs.
-      // Servers connected after the previous refresh start enabled.
-      if (firstLoad) return connectedIds;
+      // On first load, strictly restore the persisted per-request selection and
+      // do NOT auto-enable connected servers. After that, newly connected
+      // servers start enabled but explicit opt-outs are preserved.
+      if (firstLoad) {
+        const saved = new Set(plugin.settings.enabledMcpServerIds || []);
+        return new Set([...saved].filter(id => connectedIds.has(id)));
+      }
       const next = new Set([...prev].filter(id => connectedIds.has(id)));
       for (const id of connectedIds) {
         if (!previouslyKnownIds.has(id)) next.add(id);
@@ -397,6 +412,12 @@ const Chat = forwardRef<ChatRef, ChatProps>(({ plugin }, ref) => {
     void plugin.saveSettings();
   }, [plugin]);
 
+  const handleVaultToolModeChange = useCallback((mode: VaultToolMode) => {
+    setVaultToolMode(mode);
+    plugin.settings.vaultToolMode = mode;
+    void plugin.saveSettings();
+  }, [plugin]);
+
   const handleMcpServerToggle = useCallback((serverId: string, enabled: boolean) => {
     setEnabledMcpServerIds(prev => {
       const next = new Set(prev);
@@ -405,9 +426,12 @@ const Chat = forwardRef<ChatRef, ChatProps>(({ plugin }, ref) => {
       } else {
         next.delete(serverId);
       }
+      // Persist the per-request MCP selection so it survives reloads.
+      plugin.settings.enabledMcpServerIds = [...next];
+      void plugin.saveSettings();
       return next;
     });
-  }, []);
+  }, [plugin]);
 
   const handleOpenDashboard = useCallback(() => {
     if (currentDashboard) void plugin.app.workspace.getLeaf(true).openFile(currentDashboard);
@@ -1223,7 +1247,7 @@ const Chat = forwardRef<ChatRef, ChatProps>(({ plugin }, ref) => {
           void plugin.selectRagSetting(setting);
         }}
         vaultToolMode={vaultToolMode}
-        onVaultToolModeChange={setVaultToolMode}
+        onVaultToolModeChange={handleVaultToolModeChange}
         vaultFiles={vaultFiles}
         hasSelection={hasSelection}
         app={plugin.app}


### PR DESCRIPTION

The chat input has a per-request menu (next to the vault-tool button) that
lets the user toggle individual MCP servers on/off and pick the vault tool
mode (all / noSearch / none) for the next request. Previously both choices
were kept only in React component state and were lost on every Obsidian
restart, so all connected MCP servers were forced back on and the vault tool
mode reset to its default.

This is a real problem for users who run their own MCP server (e.g. an
improved hybrid-search server) alongside the plugin built-in vault tools:
after each reload the MCP server is re-enabled automatically and pollutes
the search and tool results, even though the user had deliberately turned
it off.

Changes:
- types/index.ts: add enabledMcpServerIds (string[]) to LocalLlmHubSettings
  with an empty default, so the per-request MCP selection is stored in
  data.json alongside vaultToolMode.
- Chat.tsx handleMcpServerToggle: write the toggled selection back to
  plugin.settings.enabledMcpServerIds and call saveSettings() so it persists
  immediately.
- Chat.tsx handleVaultToolModeChange: already persists vaultToolMode to
  settings on every change, so the chosen mode (all / noSearch / none)
  survives a reload.
- Chat.tsx refreshMcpServerInfos: fix the startup race where the first
  refresh runs before MCP servers finish connecting (connectedIds empty),
  which flipped the first-load branch off too early and let the newly
  connected servers start enabled rule auto-enable every server. A new
  mcpInitialRestoreDoneRef is only set once servers are actually present,
  and on first load we strictly restore from the saved list instead of
  auto-enabling connected servers.
- Chat.tsx useState initializers: seed enabledMcpServerIds and vaultToolMode
  from the saved settings so the correct state shows before the first async
  refresh.

Result: a server the user unchecked stays unchecked, the chosen vault tool
mode stays selected, and a checked server stays checked after a reload.
Newly added servers still start enabled.