### PR TITLE
fix: hide workspace folder in file tree - data-path is on .nav-folder-title, not .nav-folder

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -620,9 +620,9 @@ export class LocalLlmHubPlugin extends Plugin {
     activeDocument.querySelectorAll(".llm-hub-workspace-folder-hidden").forEach(el =>
       el.classList.remove("llm-hub-workspace-folder-hidden"));
     if (this.settings.hideWorkspaceFolder) {
-      activeDocument.querySelectorAll(".nav-folder").forEach(el => {
+      activeDocument.querySelectorAll(".nav-folder-title").forEach(el => {
         if (el.getAttribute("data-path") === this.settings.workspaceFolder) {
-          el.classList.add("llm-hub-workspace-folder-hidden");
+          el.parentElement?.classList.add("llm-hub-workspace-folder-hidden");
         }
       });
     }

--- a/styles.css
+++ b/styles.css
@@ -19,7 +19,7 @@
 }
 
 /* Hide workspace folder in file explorer */
-body.llm-hub-hide-workspace-folder .nav-folder[data-path="LocalLlmHub"] {
+body.llm-hub-hide-workspace-folder .nav-folder:has(> .nav-folder-title[data-path="LocalLlmHub"]) {
   display: none;
 }
 


### PR DESCRIPTION
CSS selector used .nav-folder[data-path=...] but data-path lives on .nav-folder-title. Changed to :has(> .nav-folder-title[data-path=...]). JS updateWorkspaceFolderVisibility now queries .nav-folder-title and adds the hidden class to parentElement.